### PR TITLE
CE-347 - ensure S3 prefix provided at CUR creation

### DIFF
--- a/modules/vertice-cur-report/variables.tf
+++ b/modules/vertice-cur-report/variables.tf
@@ -12,5 +12,4 @@ variable "cur_report_bucket_name" {
 variable "cur_report_s3_prefix" {
   type        = string
   description = "The prefix for the S3 bucket path to where the CUR data will be saved."
-  default     = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -90,5 +90,5 @@ variable "cur_report_name" {
 variable "cur_report_s3_prefix" {
   type        = string
   description = "The prefix for the S3 bucket path to where the CUR data will be saved."
-  default     = ""
+  default     = "cur"
 }


### PR DESCRIPTION
Ensure we pass in a default for S3 prefix at CUR creation time.