### PR TITLE
FEATURE CCMG-1128: Support EC2 reserved instances management

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ module "vertice_cco_integration_role" {
   cur_bucket_enabled = true
   cur_report_enabled = true
 
+  billing_policy_addons = {
+    # allow managing EC2 Reserved Instances in billing policy
+    ec2_ri = true
+  }
+
   cur_bucket_name = "vertice-cur-reports-athena-${data.aws_caller_identity.current.account_id}"
 
   cur_report_name      = "athena"
@@ -69,6 +74,7 @@ No providers.
 | Name | Description | Type | Required |
 |------|-------------|------|:--------:|
 | <a name="input_account_type"></a> [account\_type](#input\_account\_type) | The type of the AWS account. The possible values are `billing`, `member` and `combined`.<br>Use `billing` if the target account is only for billing purposes (generating CUR report and exporting it to Vertice via S3 bucket).<br>Use `member` if the account contains active workload and you want to allow `VerticeGovernance` role to perform spend optimization actions in the account on your behalf.<br>Use `combined` for both of the above. | `string` | yes |
+| <a name="input_billing_policy_addons"></a> [billing\_policy\_addons](#input\_billing\_policy\_addons) | Enable optional add-ons for the `billing`/`combined` account IAM policy. | <pre>object({<br>    ec2_ri = optional(bool, true),<br>  })</pre> | no |
 | <a name="input_cur_bucket_enabled"></a> [cur\_bucket\_enabled](#input\_cur\_bucket\_enabled) | Whether to enable the module that creates S3 bucket for Cost Usage Report data. | `bool` | no |
 | <a name="input_cur_bucket_force_destroy"></a> [cur\_bucket\_force\_destroy](#input\_cur\_bucket\_force\_destroy) | A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable. | `bool` | no |
 | <a name="input_cur_bucket_lifecycle_rules"></a> [cur\_bucket\_lifecycle\_rules](#input\_cur\_bucket\_lifecycle\_rules) | List of maps containing configuration of object lifecycle management on the S3 bucket holding CUR data. | `any` | no |

--- a/main.tf
+++ b/main.tf
@@ -6,6 +6,7 @@ module "vertice_governance_role" {
   vertice_account_ids                    = var.vertice_account_ids
   account_type                           = var.account_type
   governance_role_additional_policy_json = var.governance_role_additional_policy_json
+  billing_policy_addons                  = var.billing_policy_addons
 }
 
 module "vertice_cur_bucket" {

--- a/modules/vertice-governance-role/variables.tf
+++ b/modules/vertice-governance-role/variables.tf
@@ -25,3 +25,11 @@ variable "account_type" {
   EOT
   type        = string
 }
+
+variable "billing_policy_addons" {
+  description = "Enable optional add-ons for the `billing`/`combined` account IAM policy."
+  type = object({
+    ec2_ri = optional(bool, true),
+  })
+  default = {}
+}

--- a/variables.tf
+++ b/variables.tf
@@ -40,6 +40,14 @@ variable "governance_role_additional_policy_json" {
   default     = null
 }
 
+variable "billing_policy_addons" {
+  description = "Enable optional add-ons for the `billing`/`combined` account IAM policy."
+  type = object({
+    ec2_ri = optional(bool, true),
+  })
+  default = {}
+}
+
 ########
 ## CUR bucket module variables
 ########


### PR DESCRIPTION
Enable Vertice CCO to manage [EC2 reserved instances](https://aws.amazon.com/ec2/pricing/reserved-instances/) (RI) in customer accounts.

Equivalent AWS CloudFormation template change is at https://github.com/VerticeOne/cloudformation-aws-vertice-cco-integration/pull/2.