### PR TITLE
FEATURE CE-365 Export opinionated default as outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,11 @@ No providers.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_cur_report_name"></a> [cur\_report\_name](#output\_cur\_report\_name) | Name of the CUR report created. |
+| <a name="output_cur_report_s3_prefix"></a> [cur\_report\_s3\_prefix](#output\_cur\_report\_s3\_prefix) | Name of the S3 prefix used by the CUR report. |
 | <a name="output_role_arns"></a> [role\_arns](#output\_role\_arns) | This output is DEPRECATED and will be removed in future releases. Use vertice\_governance\_role\_arn instead. |
 | <a name="output_role_names"></a> [role\_names](#output\_role\_names) | This output is DEPRECATED and will be removed in future releases. Use vertice\_governance\_role\_name instead. |
+| <a name="output_vertice_account_ids"></a> [vertice\_account\_ids](#output\_vertice\_account\_ids) | Account IDs of Vertice allowed to access your AWS resources. |
 | <a name="output_vertice_governance_role_arn"></a> [vertice\_governance\_role\_arn](#output\_vertice\_governance\_role\_arn) | The ARN of VerticeGovernance role created. |
 | <a name="output_vertice_governance_role_name"></a> [vertice\_governance\_role\_name](#output\_vertice\_governance\_role\_name) | The name of VerticeGovernance role created. |
 <!-- END_TF_DOCS -->

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,17 @@
+output "cur_report_name" {
+  description = "Name of the CUR report created."
+  value       = var.cur_report_enabled ? var.cur_report_name : null
+}
+
+output "cur_report_s3_prefix" {
+  description = "Name of the S3 prefix used by the CUR report."
+  value       = var.cur_report_enabled ? var.cur_report_s3_prefix : null
+}
+
+output "vertice_account_ids" {
+  description = "Account IDs of Vertice allowed to access your AWS resources."
+  value       = var.governance_role_enabled ? var.vertice_account_ids : null
+}
 
 output "vertice_governance_role_arn" {
   description = "The ARN of VerticeGovernance role created."


### PR DESCRIPTION
Some default variable values (such as Vertice AWS account IDs referenced in the IAM policies created) don't usually need to be changed during normal usage, but may still need to be easily referenced by customers for use outside of the module.