### PR TITLE
FIX CE-376: Wait on bucket before report creation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -32,4 +32,6 @@ module "vertice_cur_report" {
     aws           = aws
     aws.us-east-1 = aws.us-east-1
   }
+
+  depends_on = [module.vertice_cur_bucket]
 }


### PR DESCRIPTION
The S3 bucket has to exist before a CUR report is created. Ensure the correct apply order to avoid non-existing bucket errors.

Closes #13.