### PR TITLE
FIX CE-399: Enable organizations read-only access in billing mode

### DIFF
--- a/modules/vertice-governance-role/iam_policies.tf
+++ b/modules/vertice-governance-role/iam_policies.tf
@@ -66,6 +66,8 @@ data "aws_iam_policy_document" "vertice_billing_access" {
       "ce:Get*",
       "ce:List*",
       "cur:Describe*",
+      "organizations:Describe*",
+      "organizations:List*",
       "pricing:*",
       "savingsplans:Describe*",
       "savingsplans:List*",


### PR DESCRIPTION
Read-only access to AWS Organizations is needed for the template in each mode, including billing.