### PR TITLE
FIX CE-432: Remove unnecessary pricing IAM policy statements

### DIFF
--- a/modules/vertice-governance-role/iam_policies.tf
+++ b/modules/vertice-governance-role/iam_policies.tf
@@ -68,7 +68,6 @@ data "aws_iam_policy_document" "vertice_billing_access" {
       "cur:Describe*",
       "organizations:Describe*",
       "organizations:List*",
-      "pricing:*",
       "savingsplans:Describe*",
       "savingsplans:List*",
     ]


### PR DESCRIPTION
The `pricing:*` statement is unnecessarily wide, and it's not strictly needed, so remove it from the policy.

Relates to https://github.com/VerticeOne/cloudformation-aws-vertice-cco-integration/pull/7.