### PR TITLE
FIX CE-524: Verify ExternalID using StringLike

### DIFF
--- a/modules/vertice-governance-role/main.tf
+++ b/modules/vertice-governance-role/main.tf
@@ -14,7 +14,7 @@ data "aws_iam_policy_document" "vertice_governance_assume_role" {
     }
 
     condition {
-      test     = "StringEquals"
+      test     = "StringLike"
       variable = "sts:ExternalId"
       values   = [var.governance_role_external_id]
     }


### PR DESCRIPTION
Internal testing scenarios require us to set the ExternalID to a wildcard (`*`).

Follow-up to #20.