### PR TITLE
REVERT CE-524: Hide pre-release changes from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ This is an example of creating a role in your [AWS Organizations management](htt
 
 Configuring this module to create CUR S3 bucket and CUR report in your AWS Organizations management (root/payer) account is highly recommended.
 
-For the governance IAM role to be created in your account, an ExternalId needs to be set in the `governance_role_external_id` parameter. You will receive this value from Vertice.
-
 ```hcl
 data "aws_caller_identity" "current" {}
 
@@ -33,8 +31,6 @@ module "vertice_cco_integration_role" {
 
   cur_report_name      = "athena"
   cur_report_s3_prefix = "cur"
-
-  governance_role_external_id = "<provided ExternalId value>"
 
   providers = {
     aws = aws
@@ -89,7 +85,6 @@ No providers.
 | <a name="input_cur_report_s3_prefix"></a> [cur\_report\_s3\_prefix](#input\_cur\_report\_s3\_prefix) | The prefix for the S3 bucket path to where the CUR data will be saved. | `string` | no |
 | <a name="input_governance_role_additional_policy_json"></a> [governance\_role\_additional\_policy\_json](#input\_governance\_role\_additional\_policy\_json) | Custom additional policy in JSON format to attach to VerticeGovernance role. Default is null for no additional policy. | `string` | no |
 | <a name="input_governance_role_enabled"></a> [governance\_role\_enabled](#input\_governance\_role\_enabled) | Whether to enable the module that creates VerticeGovernance role for the Cloud Cost Optimization. | `bool` | no |
-| <a name="input_governance_role_external_id"></a> [governance\_role\_external\_id](#input\_governance\_role\_external\_id) | STS external ID value to require for assuming the governance role. You will receive this from Vertice. | `string` | no |
 | <a name="input_vertice_account_ids"></a> [vertice\_account\_ids](#input\_vertice\_account\_ids) | List of Account IDs, which are allowed to access the Vertice cross account role. | `list(string)` | no |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,6 @@ module "vertice_governance_role" {
   cur_bucket_name                        = var.cur_bucket_name
   vertice_account_ids                    = var.vertice_account_ids
   account_type                           = var.account_type
-  governance_role_external_id            = var.governance_role_external_id
   governance_role_additional_policy_json = var.governance_role_additional_policy_json
   billing_policy_addons                  = var.billing_policy_addons
 }

--- a/modules/vertice-governance-role/main.tf
+++ b/modules/vertice-governance-role/main.tf
@@ -12,12 +12,6 @@ data "aws_iam_policy_document" "vertice_governance_assume_role" {
       type        = "AWS"
       identifiers = formatlist("arn:aws:iam::%s:root", var.vertice_account_ids)
     }
-
-    condition {
-      test     = "StringEquals"
-      variable = "sts:ExternalId"
-      values   = [var.governance_role_external_id]
-    }
   }
 }
 
@@ -27,11 +21,4 @@ resource "aws_iam_role" "vertice_governance_role" {
   max_session_duration = 60 * 60 * 12
 
   assume_role_policy = data.aws_iam_policy_document.vertice_governance_assume_role.json
-
-  lifecycle {
-    precondition {
-      condition     = length(var.governance_role_external_id) > 0
-      error_message = "The ExternalId for governance role must be set."
-    }
-  }
 }

--- a/modules/vertice-governance-role/main.tf
+++ b/modules/vertice-governance-role/main.tf
@@ -14,7 +14,7 @@ data "aws_iam_policy_document" "vertice_governance_assume_role" {
     }
 
     condition {
-      test     = "StringLike"
+      test     = "StringEquals"
       variable = "sts:ExternalId"
       values   = [var.governance_role_external_id]
     }

--- a/modules/vertice-governance-role/variables.tf
+++ b/modules/vertice-governance-role/variables.tf
@@ -10,12 +10,6 @@ variable "cur_bucket_name" {
   default     = null
 }
 
-variable "governance_role_external_id" {
-  type        = string
-  description = "STS external ID value to require for assuming the governance role. You will receive this from Vertice. Required if governance role is to be created."
-  default     = ""
-}
-
 variable "governance_role_additional_policy_json" {
   type        = string
   description = "Custom additional policy in JSON format to attach to VerticeGovernance role. Default is `null` for no additional policy."

--- a/variables.tf
+++ b/variables.tf
@@ -34,12 +34,6 @@ variable "governance_role_enabled" {
   default     = true
 }
 
-variable "governance_role_external_id" {
-  type        = string
-  description = "STS external ID value to require for assuming the governance role. You will receive this from Vertice."
-  default     = ""
-}
-
 variable "governance_role_additional_policy_json" {
   type        = string
   description = "Custom additional policy in JSON format to attach to VerticeGovernance role. Default is null for no additional policy."


### PR DESCRIPTION
To avoid confusion, only propagate the ExternalId changes to `main` README once released (in two weeks).