### PR TITLE
FEATURE CE-543: Prepare backwards-incompatible release v3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,6 @@ No providers.
 |------|-------------|
 | <a name="output_cur_report_name"></a> [cur\_report\_name](#output\_cur\_report\_name) | Name of the CUR report created. |
 | <a name="output_cur_report_s3_prefix"></a> [cur\_report\_s3\_prefix](#output\_cur\_report\_s3\_prefix) | Name of the S3 prefix used by the CUR report. |
-| <a name="output_role_arns"></a> [role\_arns](#output\_role\_arns) | This output is DEPRECATED and will be removed in future releases. Use vertice\_governance\_role\_arn instead. |
-| <a name="output_role_names"></a> [role\_names](#output\_role\_names) | This output is DEPRECATED and will be removed in future releases. Use vertice\_governance\_role\_name instead. |
 | <a name="output_vertice_account_ids"></a> [vertice\_account\_ids](#output\_vertice\_account\_ids) | Account IDs of Vertice allowed to access your AWS resources. |
 | <a name="output_vertice_governance_role_arn"></a> [vertice\_governance\_role\_arn](#output\_vertice\_governance\_role\_arn) | The ARN of VerticeGovernance role created. |
 | <a name="output_vertice_governance_role_name"></a> [vertice\_governance\_role\_name](#output\_vertice\_governance\_role\_name) | The name of VerticeGovernance role created. |

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ This is an example of creating a role in your [AWS Organizations management](htt
 
 Configuring this module to create CUR S3 bucket and CUR report in your AWS Organizations management (root/payer) account is highly recommended.
 
+For the governance IAM role to be created in your account, an ExternalId needs to be set in the `governance_role_external_id` parameter. You will receive this value from Vertice.
+
 ```hcl
 data "aws_caller_identity" "current" {}
 
@@ -31,6 +33,8 @@ module "vertice_cco_integration_role" {
 
   cur_report_name      = "athena"
   cur_report_s3_prefix = "cur"
+
+  governance_role_external_id = "<provided ExternalId value>"
 
   providers = {
     aws = aws
@@ -85,7 +89,7 @@ No providers.
 | <a name="input_cur_report_s3_prefix"></a> [cur\_report\_s3\_prefix](#input\_cur\_report\_s3\_prefix) | The prefix for the S3 bucket path to where the CUR data will be saved. | `string` | no |
 | <a name="input_governance_role_additional_policy_json"></a> [governance\_role\_additional\_policy\_json](#input\_governance\_role\_additional\_policy\_json) | Custom additional policy in JSON format to attach to VerticeGovernance role. Default is null for no additional policy. | `string` | no |
 | <a name="input_governance_role_enabled"></a> [governance\_role\_enabled](#input\_governance\_role\_enabled) | Whether to enable the module that creates VerticeGovernance role for the Cloud Cost Optimization. | `bool` | no |
-| <a name="input_governance_role_external_id"></a> [governance\_role\_external\_id](#input\_governance\_role\_external\_id) | STS ExternalID value to require for assuming the governance role. Not required if empty. | `string` | no |
+| <a name="input_governance_role_external_id"></a> [governance\_role\_external\_id](#input\_governance\_role\_external\_id) | STS external ID value to require for assuming the governance role. Required if the governance IAM role is to be created. You will receive this from Vertice. | `string` | no |
 | <a name="input_vertice_account_ids"></a> [vertice\_account\_ids](#input\_vertice\_account\_ids) | List of Account IDs, which are allowed to access the Vertice cross account role. | `list(string)` | no |
 
 ## Outputs

--- a/modules/vertice-governance-role/README.md
+++ b/modules/vertice-governance-role/README.md
@@ -50,7 +50,7 @@ No modules.
 | <a name="input_billing_policy_addons"></a> [billing\_policy\_addons](#input\_billing\_policy\_addons) | Enable optional add-ons for the `billing`/`combined` account IAM policy. | <pre>object({<br>    ec2_ri = optional(bool, true),<br>    rds_ri = optional(bool, true),<br>  })</pre> | `{}` | no |
 | <a name="input_cur_bucket_name"></a> [cur\_bucket\_name](#input\_cur\_bucket\_name) | The name of the bucket which will be used to store the CUR data for Vertice. | `string` | `null` | no |
 | <a name="input_governance_role_additional_policy_json"></a> [governance\_role\_additional\_policy\_json](#input\_governance\_role\_additional\_policy\_json) | Custom additional policy in JSON format to attach to VerticeGovernance role. Default is `null` for no additional policy. | `string` | `null` | no |
-| <a name="input_governance_role_external_id"></a> [governance\_role\_external\_id](#input\_governance\_role\_external\_id) | STS ExternalID value to require for assuming the governance role. Not required if empty. | `string` | `null` | no |
+| <a name="input_governance_role_external_id"></a> [governance\_role\_external\_id](#input\_governance\_role\_external\_id) | STS external ID value to require for assuming the governance role. You will receive this from Vertice. Required if governance role is to be created. | `string` | `""` | no |
 | <a name="input_vertice_account_ids"></a> [vertice\_account\_ids](#input\_vertice\_account\_ids) | List of Account IDs, which are allowed to access the Vertice cross account role. | `list(string)` | <pre>[<br>  "642184526628",<br>  "762729743961"<br>]</pre> | no |
 
 ## Outputs

--- a/modules/vertice-governance-role/README.md
+++ b/modules/vertice-governance-role/README.md
@@ -50,7 +50,7 @@ No modules.
 | <a name="input_billing_policy_addons"></a> [billing\_policy\_addons](#input\_billing\_policy\_addons) | Enable optional add-ons for the `billing`/`combined` account IAM policy. | <pre>object({<br>    ec2_ri = optional(bool, true),<br>    rds_ri = optional(bool, true),<br>  })</pre> | `{}` | no |
 | <a name="input_cur_bucket_name"></a> [cur\_bucket\_name](#input\_cur\_bucket\_name) | The name of the bucket which will be used to store the CUR data for Vertice. | `string` | `null` | no |
 | <a name="input_governance_role_additional_policy_json"></a> [governance\_role\_additional\_policy\_json](#input\_governance\_role\_additional\_policy\_json) | Custom additional policy in JSON format to attach to VerticeGovernance role. Default is `null` for no additional policy. | `string` | `null` | no |
-| <a name="input_governance_role_external_id"></a> [governance\_role\_external\_id](#input\_governance\_role\_external\_id) | STS external ID value to require for assuming the governance role. You will receive this from Vertice. Required if governance role is to be created. | `string` | `""` | no |
+| <a name="input_governance_role_external_id"></a> [governance\_role\_external\_id](#input\_governance\_role\_external\_id) | STS external ID value to require for assuming the governance role. Required if the governance IAM role is to be created. You will receive this from Vertice. | `string` | `""` | no |
 | <a name="input_vertice_account_ids"></a> [vertice\_account\_ids](#input\_vertice\_account\_ids) | List of Account IDs, which are allowed to access the Vertice cross account role. | `list(string)` | <pre>[<br>  "642184526628",<br>  "762729743961"<br>]</pre> | no |
 
 ## Outputs

--- a/modules/vertice-governance-role/main.tf
+++ b/modules/vertice-governance-role/main.tf
@@ -13,13 +13,10 @@ data "aws_iam_policy_document" "vertice_governance_assume_role" {
       identifiers = formatlist("arn:aws:iam::%s:root", var.vertice_account_ids)
     }
 
-    dynamic "condition" {
-      for_each = compact([var.governance_role_external_id])
-      content {
-        test     = "StringEquals"
-        variable = "sts:ExternalId"
-        values   = [var.governance_role_external_id]
-      }
+    condition {
+      test     = "StringEquals"
+      variable = "sts:ExternalId"
+      values   = [var.governance_role_external_id]
     }
   }
 }
@@ -30,4 +27,11 @@ resource "aws_iam_role" "vertice_governance_role" {
   max_session_duration = 60 * 60 * 12
 
   assume_role_policy = data.aws_iam_policy_document.vertice_governance_assume_role.json
+
+  lifecycle {
+    precondition {
+      condition     = length(var.governance_role_external_id) > 0
+      error_message = "The ExternalId for governance role must be set."
+    }
+  }
 }

--- a/modules/vertice-governance-role/variables.tf
+++ b/modules/vertice-governance-role/variables.tf
@@ -12,7 +12,7 @@ variable "cur_bucket_name" {
 
 variable "governance_role_external_id" {
   type        = string
-  description = "STS external ID value to require for assuming the governance role. You will receive this from Vertice. Required if governance role is to be created."
+  description = "STS external ID value to require for assuming the governance role. Required if the governance IAM role is to be created. You will receive this from Vertice."
   default     = ""
 }
 

--- a/modules/vertice-governance-role/variables.tf
+++ b/modules/vertice-governance-role/variables.tf
@@ -12,8 +12,8 @@ variable "cur_bucket_name" {
 
 variable "governance_role_external_id" {
   type        = string
-  description = "STS ExternalID value to require for assuming the governance role. Not required if empty."
-  default     = null
+  description = "STS external ID value to require for assuming the governance role. You will receive this from Vertice. Required if governance role is to be created."
+  default     = ""
 }
 
 variable "governance_role_additional_policy_json" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -22,18 +22,3 @@ output "vertice_governance_role_name" {
   description = "The name of VerticeGovernance role created."
   value       = var.governance_role_enabled ? one(module.vertice_governance_role[*].vertice_governance_role_name) : null
 }
-
-########
-## The following outputs are DEPRECATED.
-## They are here only for the backwards compatibility
-########
-
-output "role_arns" {
-  description = "This output is DEPRECATED and will be removed in future releases. Use vertice_governance_role_arn instead."
-  value       = { "VerticeGovernanceRole" = var.governance_role_enabled ? one(module.vertice_governance_role[*].vertice_governance_role_arn) : null }
-}
-
-output "role_names" {
-  description = "This output is DEPRECATED and will be removed in future releases. Use vertice_governance_role_name instead."
-  value       = { "VerticeGovernanceRole" = var.governance_role_enabled ? one(module.vertice_governance_role[*].vertice_governance_role_name) : null }
-}

--- a/variables.tf
+++ b/variables.tf
@@ -36,8 +36,8 @@ variable "governance_role_enabled" {
 
 variable "governance_role_external_id" {
   type        = string
-  description = "STS ExternalID value to require for assuming the governance role. Not required if empty."
-  default     = null
+  description = "STS external ID value to require for assuming the governance role. Required if the governance IAM role is to be created. You will receive this from Vertice."
+  default     = ""
 }
 
 variable "governance_role_additional_policy_json" {


### PR DESCRIPTION
Prepare a release with breaking changes, including:
* require `ExternalId` when creating the governance IAM role
* remove deprecated outputs