### PR TITLE
FIX CCMG-1729: Require CUR bucket name when needed

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ module "vertice_governance_role" {
 }
 
 module "vertice_cur_bucket" {
-  count  = var.cur_bucket_enabled && (var.account_type == "billing" || var.account_type == "combined") && var.cur_bucket_name != null ? 1 : 0
+  count  = var.cur_bucket_enabled && (var.account_type == "billing" || var.account_type == "combined") ? 1 : 0
   source = "./modules/vertice-cur-bucket"
 
   cur_bucket_name            = var.cur_bucket_name

--- a/modules/vertice-cur-bucket/variables.tf
+++ b/modules/vertice-cur-bucket/variables.tf
@@ -1,6 +1,7 @@
 variable "cur_bucket_name" {
   type        = string
   description = "The name of the bucket which will be used to store the CUR data for Vertice."
+  nullable    = false
 }
 
 variable "cur_bucket_force_destroy" {

--- a/modules/vertice-cur-report/variables.tf
+++ b/modules/vertice-cur-report/variables.tf
@@ -7,6 +7,7 @@ variable "cur_report_name" {
 variable "cur_report_bucket_name" {
   type        = string
   description = "The name of the bucket which will be used to store the CUR data for Vertice."
+  nullable    = false
 }
 
 variable "cur_report_s3_prefix" {


### PR DESCRIPTION
The `cur_report_bucket` variable is not required for creating the governance IAM role, but has to be non-null when creating the bucket or report. Mark it as non-nullable in the relevant submodules.