### PR TITLE
FIX CCMG-1729: Deny insecure connection to S3 bucket

### DIFF
--- a/modules/vertice-governance-role/iam_policies.tf
+++ b/modules/vertice-governance-role/iam_policies.tf
@@ -31,6 +31,33 @@ data "aws_iam_policy_document" "vertice_cur_bucket_access" {
     ]
   }
 
+  statement {
+    sid    = "AllowSSLRequestsOnly"
+    effect = "Deny"
+
+    actions = [
+      "s3:*",
+    ]
+
+    resources = [
+      "arn:aws:s3:::${var.cur_bucket_name}",
+      "arn:aws:s3:::${var.cur_bucket_name}/*"
+    ]
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values = [
+        "false"
+      ]
+    }
+  }
+
   lifecycle {
     precondition {
       condition     = var.cur_bucket_name != null


### PR DESCRIPTION
Adhere to the industry standard of only allowing bucket access via HTTPS.