### PR TITLE
fix: Add missing default aws provider to README.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ module "vertice_cco_integration_role" {
   }
 }
 
+provider "aws" {
+  region = "us-west-2" # Replace with desired region for the CUR S3 bucket
+}
+
 # Cost and Usage Report only exists in us-east-1
 provider "aws" {
   alias  = "us-east-1"


### PR DESCRIPTION
Running the example as-is generates an error due to the default `aws` provider instantiation missing:
```hcl
Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: Invalid provider configuration
│ 
│ Provider "registry.terraform.io/hashicorp/aws" requires explicit configuration. Add a provider block to the root module and configure the provider's required arguments as described in the provider
│ documentation.
│ 
╵
╷
│ Error: Invalid AWS Region: 
│ 
│   with provider["registry.terraform.io/hashicorp/aws"],
│   on <empty> line 0:
│   (source code not available)
│ 
╵
```