### PR TITLE
FEATURE ASH-56: Support Split Cost Allocation Data in CUR

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,14 @@ terraform {
 }
 ```
 
+### Split Cost Allocation Data
+
+The module supports the [Split Cost Allocation Data](https://aws.amazon.com/blogs/aws-cloud-financial-management/improve-cost-visibility-of-amazon-eks-with-aws-split-cost-allocation-data/) opt-in feature of the Cost and Usage Report, which provides more granular data for ECS/EKS usage. Please note that this feature may increase your costs slightly due to a larger volume of usage data generated.
+
+To enable this feature:
+1. Opt in to Split Cost Allocation Data in the [Cost Management Preferences](https://us-east-1.console.aws.amazon.com/costmanagement/home?region=eu-west-1#/settings) page of the AWS Console (Step 1 of the guide above).
+2. Set the `cur_report_split_cost_data = true` variable on this module.
+
 <!-- markdownlint-disable -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
@@ -99,6 +107,7 @@ No providers.
 | <a name="input_cur_report_enabled"></a> [cur\_report\_enabled](#input\_cur\_report\_enabled) | Whether to enable the module that creates S3 bucket for Cost Usage Report data. | `bool` | no |
 | <a name="input_cur_report_name"></a> [cur\_report\_name](#input\_cur\_report\_name) | The name of the CUR report for Vertice. | `string` | no |
 | <a name="input_cur_report_s3_prefix"></a> [cur\_report\_s3\_prefix](#input\_cur\_report\_s3\_prefix) | The prefix for the S3 bucket path to where the CUR data will be saved. | `string` | no |
+| <a name="input_cur_report_split_cost_data"></a> [cur\_report\_split\_cost\_data](#input\_cur\_report\_split\_cost\_data) | Enable Split Cost Allocation Data inclusion in CUR. Note that manual opt-in is needed in AWS Console. | `bool` | no |
 | <a name="input_governance_role_additional_policy_json"></a> [governance\_role\_additional\_policy\_json](#input\_governance\_role\_additional\_policy\_json) | Custom additional policy in JSON format to attach to VerticeGovernance role. Default is null for no additional policy. | `string` | no |
 | <a name="input_governance_role_enabled"></a> [governance\_role\_enabled](#input\_governance\_role\_enabled) | Whether to enable the module that creates VerticeGovernance role for the Cloud Cost Optimization. | `bool` | no |
 | <a name="input_governance_role_external_id"></a> [governance\_role\_external\_id](#input\_governance\_role\_external\_id) | STS external ID value to require for assuming the governance role. Required if the governance IAM role is to be created. You will receive this from Vertice. | `string` | no |

--- a/main.tf
+++ b/main.tf
@@ -28,6 +28,8 @@ module "vertice_cur_report" {
   cur_report_bucket_name = var.cur_bucket_name
   cur_report_s3_prefix   = var.cur_report_s3_prefix
 
+  cur_report_split_cost_data = var.cur_report_split_cost_data
+
   ## CUR report is currently available only in the us-east-1 region
   providers = {
     aws           = aws

--- a/modules/vertice-cur-report/README.md
+++ b/modules/vertice-cur-report/README.md
@@ -14,8 +14,8 @@ Sub-module responsible for the creation of an AWS Cost and Usage Report (CUR).
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.64.0 |
-| <a name="provider_aws.us-east-1"></a> [aws.us-east-1](#provider\_aws.us-east-1) | >= 4.64.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.41.0 |
+| <a name="provider_aws.us-east-1"></a> [aws.us-east-1](#provider\_aws.us-east-1) | 5.41.0 |
 
 ## Modules
 
@@ -35,6 +35,7 @@ No modules.
 | <a name="input_cur_report_bucket_name"></a> [cur\_report\_bucket\_name](#input\_cur\_report\_bucket\_name) | The name of the bucket which will be used to store the CUR data for Vertice. | `string` | n/a | yes |
 | <a name="input_cur_report_name"></a> [cur\_report\_name](#input\_cur\_report\_name) | The name of the CUR report for Vertice. | `string` | `"vertice-cur-report"` | no |
 | <a name="input_cur_report_s3_prefix"></a> [cur\_report\_s3\_prefix](#input\_cur\_report\_s3\_prefix) | The prefix for the S3 bucket path to where the CUR data will be saved. | `string` | n/a | yes |
+| <a name="input_cur_report_split_cost_data"></a> [cur\_report\_split\_cost\_data](#input\_cur\_report\_split\_cost\_data) | Enable Split Cost Allocation Data inclusion in CUR. Note that manual opt-in is needed in AWS Console. | `bool` | `false` | no |
 
 ## Outputs
 

--- a/modules/vertice-cur-report/main.tf
+++ b/modules/vertice-cur-report/main.tf
@@ -9,9 +9,10 @@ resource "aws_cur_report_definition" "vertice_cur_report" {
   format      = "Parquet"
   compression = "Parquet"
 
-  additional_schema_elements = [
-    "RESOURCES",
-  ]
+  additional_schema_elements = concat(
+    ["RESOURCES"],
+    var.cur_report_split_cost_data ? ["SPLIT_COST_ALLOCATION_DATA"] : [],
+  )
 
   s3_bucket = data.aws_s3_bucket.vertice_cur_bucket.bucket
   s3_region = data.aws_s3_bucket.vertice_cur_bucket.region

--- a/modules/vertice-cur-report/variables.tf
+++ b/modules/vertice-cur-report/variables.tf
@@ -14,3 +14,9 @@ variable "cur_report_s3_prefix" {
   type        = string
   description = "The prefix for the S3 bucket path to where the CUR data will be saved."
 }
+
+variable "cur_report_split_cost_data" {
+  type        = bool
+  description = "Enable Split Cost Allocation Data inclusion in CUR. Note that manual opt-in is needed in AWS Console."
+  default     = false
+}

--- a/variables.tf
+++ b/variables.tf
@@ -107,3 +107,9 @@ variable "cur_report_s3_prefix" {
   description = "The prefix for the S3 bucket path to where the CUR data will be saved."
   default     = "cur"
 }
+
+variable "cur_report_split_cost_data" {
+  type        = bool
+  description = "Enable Split Cost Allocation Data inclusion in CUR. Note that manual opt-in is needed in AWS Console."
+  default     = false
+}


### PR DESCRIPTION
Add support for the [Split Cost Allocation Data](https://aws.amazon.com/blogs/aws-cloud-financial-management/improve-cost-visibility-of-amazon-eks-with-aws-split-cost-allocation-data/) opt-in functionality of the Cost and Usage Report.

Extend README to notify about possible additional costs, as well as the need for a manual opt-in in AWS Console.

Relates to https://github.com/VerticeOne/cloudformation-aws-vertice-cco-integration/pull/25.