### PR TITLE
FIX ASH-189: Update obsolete Terraform version requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ provider "aws" {
 }
 
 terraform {
-  required_version = ">= 1.1.4"
+  required_version = ">= 1.3.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
@@ -86,7 +86,7 @@ To enable this feature:
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.4 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.64.0 |
 
 ## Providers

--- a/modules/vertice-cur-bucket/README.md
+++ b/modules/vertice-cur-bucket/README.md
@@ -7,7 +7,7 @@ Sub-module responsible for the creation of an S3 bucket for collecting AWS cost 
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.4 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.64.0 |
 
 ## Providers

--- a/modules/vertice-cur-bucket/providers.tf
+++ b/modules/vertice-cur-bucket/providers.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.1.4"
+  required_version = ">= 1.3.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/modules/vertice-cur-report/README.md
+++ b/modules/vertice-cur-report/README.md
@@ -7,7 +7,7 @@ Sub-module responsible for the creation of an AWS Cost and Usage Report (CUR).
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.4 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.64.0 |
 
 ## Providers

--- a/modules/vertice-cur-report/providers.tf
+++ b/modules/vertice-cur-report/providers.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.1.4"
+  required_version = ">= 1.3.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/modules/vertice-governance-role/README.md
+++ b/modules/vertice-governance-role/README.md
@@ -7,7 +7,7 @@ Sub-module responsible for the creation of an IAM role assumable by Vertice.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.4 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.64.0 |
 
 ## Providers

--- a/modules/vertice-governance-role/providers.tf
+++ b/modules/vertice-governance-role/providers.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.1.4"
+  required_version = ">= 1.3.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/providers.tf
+++ b/providers.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.1.4"
+  required_version = ">= 1.3.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
We rely on optional attributes in object-type variables, introduced in [Terraform 1.3.0](https://github.com/hashicorp/terraform/blob/v1.3/CHANGELOG.md#130-september-21-2022). However, we've previously failed to reflect this in the Terraform `required_version` constraint; let's fix that.