### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ data "aws_caller_identity" "current" {}
 module "vertice_cco_integration_role" {
   source        = "git::https://github.com/VerticeOne/terraform-aws-vertice-integration.git?ref=<release-version>"
 
-  account_type = "billing"
+  account_type = "combined"
   cur_bucket_enabled = true
   cur_report_enabled = true
 


### PR DESCRIPTION
The default option is what most customers are using as a template.

`account_type = "billing"` does not trigger `core_access_enabled` see [here](https://github.com/VerticeOne/terraform-aws-vertice-integration/blob/4816f4439f95bd0d26b1a401ad77d9fe13e4c695/modules/vertice-governance-role/iam_policies.tf#L4)

as a result I see many customers coming through missing the majority of the permisssions