### PR TITLE
FIX ASH-2094: add .env to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ out/
 
 # other
 .*.swp
+.env


### PR DESCRIPTION
Prevent committing local secrets by ignoring `.env`.

Ref: https://vertice.atlassian.net/browse/ASH-2094